### PR TITLE
[WIP] Avoid truncation when longer output, ref. #6267

### DIFF
--- a/changelog/6267.feature.rst
+++ b/changelog/6267.feature.rst
@@ -1,0 +1,2 @@
+When output is close to truncation limit, we now write 'N lines hidden [1 truncated]',
+instead of 'N+1 lines hidden' - last line which we show isn't really hidden always, neither it's always really truncated.

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -73,7 +73,7 @@ def _truncate_explanation(input_lines, max_lines=None, max_chars=None):
     else:
         msg += " ({} lines hidden".format(truncated_line_count)
     if last_truncated:
-        msg += ",1 truncated)"
+        msg += ", 1 truncated)"
     else:
         msg += ")"
     msg += ", {}".format(USAGE_MSG)

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -50,7 +50,6 @@ def _truncate_explanation(input_lines, max_lines=None, max_chars=None):
         max_chars = DEFAULT_MAX_CHARS
 
     # Check if truncation required
-
     input_char_count = len("".join(input_lines))
     if len(input_lines) <= max_lines and input_char_count <= max_chars:
         return input_lines

--- a/src/_pytest/assertion/truncate.py
+++ b/src/_pytest/assertion/truncate.py
@@ -40,6 +40,8 @@ def _truncate_explanation(input_lines, max_lines=None, max_chars=None):
 
     Truncates to either 8 lines, or 640 characters - whichever the input reaches
     first. The remaining lines will be replaced by a usage message.
+
+    Check https://github.com/pytest-dev/pytest/issues/6267 for corner cases
     """
 
     if max_lines is None:
@@ -48,6 +50,7 @@ def _truncate_explanation(input_lines, max_lines=None, max_chars=None):
         max_chars = DEFAULT_MAX_CHARS
 
     # Check if truncation required
+
     input_char_count = len("".join(input_lines))
     if len(input_lines) <= max_lines and input_char_count <= max_chars:
         return input_lines
@@ -62,12 +65,18 @@ def _truncate_explanation(input_lines, max_lines=None, max_chars=None):
 
     # Append useful message to explanation
     truncated_line_count = len(input_lines) - len(truncated_explanation)
-    truncated_line_count += 1  # Account for the part-truncated final line
     msg = "...Full output truncated"
+    last_truncated = not (
+        input_lines[len(truncated_explanation) - 1] in truncated_explanation[-1]
+    )
     if truncated_line_count == 1:
-        msg += " ({} line hidden)".format(truncated_line_count)
+        msg += " ({} line hidden".format(truncated_line_count)
     else:
-        msg += " ({} lines hidden)".format(truncated_line_count)
+        msg += " ({} lines hidden".format(truncated_line_count)
+    if last_truncated:
+        msg += ",1 truncated)"
+    else:
+        msg += ")"
     msg += ", {}".format(USAGE_MSG)
     truncated_explanation.extend(["", str(msg)])
     return truncated_explanation


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [ ] Target the `features` branch for new features, improvements, and removals/deprecations.
- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->
Fixes #6267 
Surely, because it's user-facing change, documentation/tests would need to change too, but now it's rather a proposal to mentioned issue.