### PR TITLE
Fix issue where working dir becomes wrong on subst drive on Windows. Fixes #5965

### DIFF
--- a/changelog/5965.bugfix.rst
+++ b/changelog/5965.bugfix.rst
@@ -1,0 +1,1 @@
+No longer resolve symlinks so that the current directory remains correct with drives mapped with subst on Windows or symlinks on Linux.

--- a/src/_pytest/config/__init__.py
+++ b/src/_pytest/config/__init__.py
@@ -208,7 +208,7 @@ def get_config(args=None, plugins=None):
     config = Config(
         pluginmanager,
         invocation_params=Config.InvocationParams(
-            args=args or (), plugins=plugins, dir=Path().resolve()
+            args=args or (), plugins=plugins, dir=Path.cwd()
         ),
     )
 
@@ -462,7 +462,7 @@ class PytestPluginManager(PluginManager):
         # and allow users to opt into looking into the rootdir parent
         # directories instead of requiring to specify confcutdir
         clist = []
-        for parent in directory.realpath().parts():
+        for parent in directory.parts():
             if self._confcutdir and self._confcutdir.relto(parent):
                 continue
             conftestpath = parent.join("conftest.py")
@@ -771,7 +771,7 @@ class Config:
 
         if invocation_params is None:
             invocation_params = self.InvocationParams(
-                args=(), plugins=None, dir=Path().resolve()
+                args=(), plugins=None, dir=Path.cwd()
             )
 
         self.option = argparse.Namespace()

--- a/src/_pytest/fixtures.py
+++ b/src/_pytest/fixtures.py
@@ -1288,7 +1288,7 @@ class FixtureManager:
     def pytest_plugin_registered(self, plugin):
         nodeid = None
         try:
-            p = py.path.local(plugin.__file__).realpath()
+            p = py.path.local(plugin.__file__)
         except AttributeError:
             pass
         else:

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -642,7 +642,6 @@ class Session(nodes.FSCollector):
                     "file or package not found: " + arg + " (missing __init__.py?)"
                 )
             raise UsageError("file not found: " + arg)
-        fspath = fspath.realpath()
         return (fspath, parts)
 
     def matchnodes(self, matching, names):

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -822,8 +822,8 @@ class TestInvocationVariants:
         if hasattr(py.path.local, "mksymlinkto"):
             result.stdout.fnmatch_lines(
                 [
-                    "lib/foo/bar/test_bar.py::test_bar PASSED*",
-                    "lib/foo/bar/test_bar.py::test_other PASSED*",
+                    "local/lib/foo/bar/test_bar.py::test_bar PASSED*",
+                    "local/lib/foo/bar/test_bar.py::test_other PASSED*",
                     "*2 passed*",
                 ]
             )

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -1171,13 +1171,13 @@ def test_collect_symlink_file_arg(testdir):
     real = testdir.makepyfile(
         real="""
         def test_nodeid(request):
-            assert request.node.nodeid == "real.py::test_nodeid"
+            assert request.node.nodeid == "symlink.py::test_nodeid"
         """
     )
     symlink = testdir.tmpdir.join("symlink.py")
     symlink.mksymlinkto(real)
     result = testdir.runpytest("-v", symlink)
-    result.stdout.fnmatch_lines(["real.py::test_nodeid PASSED*", "*1 passed in*"])
+    result.stdout.fnmatch_lines(["symlink.py::test_nodeid PASSED*", "*1 passed in*"])
     assert result.ret == 0
 
 

--- a/testing/test_link_resolve.py
+++ b/testing/test_link_resolve.py
@@ -1,0 +1,85 @@
+import os.path
+import subprocess
+import sys
+import textwrap
+from contextlib import contextmanager
+from string import ascii_lowercase
+
+import py.path
+
+from _pytest import pytester
+
+
+@contextmanager
+def subst_path_windows(filename):
+    for c in ascii_lowercase[7:]:  # Create a subst drive from H-Z.
+        c += ":"
+        if not os.path.exists(c):
+            drive = c
+            break
+    else:
+        raise AssertionError("Unable to find suitable drive letter for subst.")
+
+    directory = filename.dirpath()
+    basename = filename.basename
+
+    args = ["subst", drive, str(directory)]
+    subprocess.check_call(args)
+    assert os.path.exists(drive)
+    try:
+        filename = py.path.local(drive) / basename
+        yield filename
+    finally:
+        args = ["subst", "/D", drive]
+        subprocess.check_call(args)
+
+
+@contextmanager
+def subst_path_linux(filename):
+    directory = filename.dirpath()
+    basename = filename.basename
+
+    target = directory / ".." / "sub2"
+    os.symlink(str(directory), str(target), target_is_directory=True)
+    try:
+        filename = target / basename
+        yield filename
+    finally:
+        # We don't need to unlink (it's all in the tempdir).
+        pass
+
+
+def test_link_resolve(testdir: pytester.Testdir) -> None:
+    """
+    See: https://github.com/pytest-dev/pytest/issues/5965
+    """
+    sub1 = testdir.mkpydir("sub1")
+    p = sub1.join("test_foo.py")
+    p.write(
+        textwrap.dedent(
+            """
+        import pytest
+        def test_foo():
+            raise AssertionError()
+        """
+        )
+    )
+
+    subst = subst_path_linux
+    if sys.platform == "win32":
+        subst = subst_path_windows
+
+    with subst(p) as subst_p:
+        result = testdir.runpytest(str(subst_p), "-v")
+        # i.e.: Make sure that the error is reported as a relative path, not as a
+        # resolved path.
+        # See: https://github.com/pytest-dev/pytest/issues/5965
+        stdout = result.stdout.str()
+        assert "sub1/test_foo.py" not in stdout
+
+        # i.e.: Expect drive on windows because we just have drive:filename, whereas
+        # we expect a relative path on Linux.
+        expect = (
+            "*{}*".format(subst_p) if sys.platform == "win32" else "*sub2/test_foo.py*"
+        )
+        result.stdout.fnmatch_lines([expect])


### PR DESCRIPTION
Note that I didn't change all the `Path.resolve()` occurrences on `pytest`, only the ones related to getting the current directory.

#5965