### PR TITLE
WIP Node._repr_failure_py: use abspath with changed cwd

### DIFF
--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -325,8 +325,7 @@ class Node(metaclass=NodeMeta):
             truncate_locals = True
 
         try:
-            os.getcwd()
-            abspath = False
+            abspath = os.getcwd() != str(self.config.invocation_dir)
         except OSError:
             abspath = True
 


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/6428.

TODO:

- [ ] test
- [ ] changelog
- [ ] use relative path to invocation dir