### PR TITLE
Add --no-trace option, overrides pytrace=True for pytest.fail

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -110,6 +110,7 @@ Grig Gheorghiu
 Grigorii Eremeev (budulianin)
 Guido Wesdorp
 Guoqiang Zhang
+Guy Perry
 Harald Armin Massa
 Henk-Jaap Wagenaar
 Holger Kohr

--- a/changelog/6651.feature.rst
+++ b/changelog/6651.feature.rst
@@ -1,0 +1,2 @@
+Add the --no-trace flag, allowing to override `pytrace=True` for `pytest.fail` calls.
+This is useful to avoid automated `pytest` runs outputting unwanted information.

--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -180,6 +180,13 @@ def pytest_addoption(parser):
         default=False,
         help="Don't ignore tests in a local virtualenv directory",
     )
+    group.addoption(
+        "--notrace",
+        "--no-trace",
+        action="store_true",
+        default=False,
+        help="Do not output any traceback in case of failure, even when passing pytrace=True",
+    )
 
     group = parser.getgroup("debugconfig", "test session debugging and configuration")
     group.addoption(

--- a/src/_pytest/nodes.py
+++ b/src/_pytest/nodes.py
@@ -287,7 +287,9 @@ class Node:
         self, excinfo: ExceptionInfo[Union[Failed, FixtureLookupError]], style=None
     ) -> Union[str, ReprExceptionInfo, ExceptionChainRepr, FixtureLookupErrorRepr]:
         if isinstance(excinfo.value, Failed):
-            if not excinfo.value.pytrace:
+            if (
+                self.config is not None and self.config.getoption("notrace")
+            ) or not excinfo.value.pytrace:
                 return str(excinfo.value)
         if isinstance(excinfo.value, FixtureLookupError):
             return excinfo.value.formatrepr()

--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -629,7 +629,7 @@ def test_pytest_exit_returncode(testdir) -> None:
     assert result.ret == 98
 
 
-def test_pytest_fail_notrace_runtest(testdir) -> None:
+def test_pytest_fail_pytrace_false_runtest(testdir) -> None:
     """Test pytest.fail(..., pytrace=False) does not show tracebacks during test run."""
     testdir.makepyfile(
         """
@@ -645,7 +645,23 @@ def test_pytest_fail_notrace_runtest(testdir) -> None:
     result.stdout.no_fnmatch_line("*def teardown_function*")
 
 
-def test_pytest_fail_notrace_collection(testdir) -> None:
+def test_pytest_fail_notrace_pytrace_true_runtest(testdir) -> None:
+    """Test pytest.fail(..., pytrace=True) does not show tracebacks when passing --no-trace."""
+    testdir.makepyfile(
+        """
+        import pytest
+        def test_hello():
+            pytest.fail("hello", pytrace=True)
+        def teardown_function(function):
+            pytest.fail("world", pytrace=True)
+    """
+    )
+    result = testdir.runpytest("--no-trace")
+    result.stdout.fnmatch_lines(["world", "hello"])
+    result.stdout.no_fnmatch_line("*def teardown_function*")
+
+
+def test_pytest_fail_pytrace_false_collection(testdir) -> None:
     """Test pytest.fail(..., pytrace=False) does not show tracebacks during collection."""
     testdir.makepyfile(
         """
@@ -660,7 +676,7 @@ def test_pytest_fail_notrace_collection(testdir) -> None:
     result.stdout.no_fnmatch_line("*def some_internal_function()*")
 
 
-def test_pytest_fail_notrace_non_ascii(testdir) -> None:
+def test_pytest_fail_pytrace_false_non_ascii(testdir) -> None:
     """Fix pytest.fail with pytrace=False with non-ascii characters (#1178).
 
     This tests with native and unicode strings containing non-ascii chars.


### PR DESCRIPTION
Hey, I just opened [this issue](https://github.com/pytest-dev/pytest/issues/6651) to open a PR for the fork I'll be using for my automated exercise testing.
Hoping this change can be useful to others as well :smile: 