### PR TITLE
tests: re-harden test_cmdline_python_package_symlink

### DIFF
--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -268,10 +268,6 @@ class TestGeneralUsage:
         assert result.ret != 0
         assert "should be seen" in result.stdout.str()
 
-    @pytest.mark.skipif(
-        not hasattr(py.path.local, "mksymlinkto"),
-        reason="symlink not available on this platform",
-    )
     def test_chdir(self, testdir):
         testdir.tmpdir.join("py").mksymlinkto(py._pydir)
         p = testdir.tmpdir.join("main.py")
@@ -819,22 +815,13 @@ class TestInvocationVariants:
         result = testdir.runpytest("--pyargs", "-v", "foo.bar")
         testdir.chdir()
         assert result.ret == 0
-        if hasattr(py.path.local, "mksymlinkto"):
-            result.stdout.fnmatch_lines(
-                [
-                    "lib/foo/bar/test_bar.py::test_bar PASSED*",
-                    "lib/foo/bar/test_bar.py::test_other PASSED*",
-                    "*2 passed*",
-                ]
-            )
-        else:
-            result.stdout.fnmatch_lines(
-                [
-                    "local/lib/foo/bar/test_bar.py::test_bar PASSED*",
-                    "local/lib/foo/bar/test_bar.py::test_other PASSED*",
-                    "*2 passed*",
-                ]
-            )
+        result.stdout.fnmatch_lines(
+            [
+                "local/lib/foo/bar/test_bar.py::test_bar PASSED*",
+                "local/lib/foo/bar/test_bar.py::test_other PASSED*",
+                "*2 passed*",
+            ]
+        )
 
     def test_cmdline_python_package_not_exists(self, testdir):
         result = testdir.runpytest("--pyargs", "tpkgwhatv")

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -817,8 +817,8 @@ class TestInvocationVariants:
         assert result.ret == 0
         result.stdout.fnmatch_lines(
             [
-                "local/lib/foo/bar/test_bar.py::test_bar PASSED*",
-                "local/lib/foo/bar/test_bar.py::test_other PASSED*",
+                "lib/foo/bar/test_bar.py::test_bar PASSED*",
+                "lib/foo/bar/test_bar.py::test_other PASSED*",
                 "*2 passed*",
             ]
         )

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -268,6 +268,10 @@ class TestGeneralUsage:
         assert result.ret != 0
         assert "should be seen" in result.stdout.str()
 
+    @pytest.mark.skipif(
+        not hasattr(py.path.local, "mksymlinkto"),
+        reason="symlink not available on this platform",
+    )
     def test_chdir(self, testdir):
         testdir.tmpdir.join("py").mksymlinkto(py._pydir)
         p = testdir.tmpdir.join("main.py")

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -762,21 +762,13 @@ class TestInvocationVariants:
         result = testdir.runpytest(str(p) + "::test", "--doctest-modules")
         result.stdout.fnmatch_lines(["*1 passed*"])
 
-    def test_cmdline_python_package_symlink(self, testdir, monkeypatch):
+    def test_cmdline_python_package_symlink(
+        self, testdir, monkeypatch, symlink_or_skip
+    ):
         """
         test --pyargs option with packages with path containing symlink can
         have conftest.py in their package (#2985)
         """
-        # dummy check that we can actually create symlinks: on Windows `os.symlink` is available,
-        # but normal users require special admin privileges to create symlinks.
-        if sys.platform == "win32":
-            try:
-                os.symlink(
-                    str(testdir.tmpdir.ensure("tmpfile")),
-                    str(testdir.tmpdir.join("tmpfile2")),
-                )
-            except OSError as e:
-                pytest.skip(str(e.args[0]))
         monkeypatch.delenv("PYTHONDONTWRITEBYTECODE", raising=False)
 
         dirname = "lib"
@@ -794,7 +786,7 @@ class TestInvocationVariants:
 
         d_local = testdir.mkdir("local")
         symlink_location = os.path.join(str(d_local), "lib")
-        os.symlink(str(d), symlink_location, target_is_directory=True)
+        symlink_or_skip(str(d), symlink_location, target_is_directory=True)
 
         # The structure of the test directory is now:
         # .

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -825,8 +825,8 @@ class TestInvocationVariants:
         else:
             result.stdout.fnmatch_lines(
                 [
-                    "*lib/foo/bar/test_bar.py::test_bar PASSED*",
-                    "*lib/foo/bar/test_bar.py::test_other PASSED*",
+                    "local/lib/foo/bar/test_bar.py::test_bar PASSED*",
+                    "local/lib/foo/bar/test_bar.py::test_other PASSED*",
                     "*2 passed*",
                 ]
             )

--- a/testing/acceptance_test.py
+++ b/testing/acceptance_test.py
@@ -830,8 +830,8 @@ class TestInvocationVariants:
         else:
             result.stdout.fnmatch_lines(
                 [
-                    "*lib/foo/bar/test_bar.py::test_bar PASSED*",
-                    "*lib/foo/bar/test_bar.py::test_other PASSED*",
+                    "local/lib/foo/bar/test_bar.py::test_bar PASSED*",
+                    "local/lib/foo/bar/test_bar.py::test_other PASSED*",
                     "*2 passed*",
                 ]
             )

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 from typing import List
@@ -134,6 +135,24 @@ def dummy_yaml_custom_test(testdir):
 def testdir(testdir: Testdir) -> Testdir:
     testdir.monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
     return testdir
+
+
+@pytest.fixture
+def symlink_or_skip():
+    """Return a function to create symlinks or skip the test.
+
+    On Windows `os.symlink` is available, but normal users require special
+    admin privileges to create symlinks.
+    """
+
+    def wrap_os_symlink(src, dst, *args, **kwargs):
+        try:
+            os.symlink(src, dst, *args, **kwargs)
+        except OSError as e:
+            pytest.skip("os.symlink({!r}) failed: {!r}".format((src, dst), e))
+        assert os.path.islink(dst)
+
+    return wrap_os_symlink
 
 
 @pytest.fixture(scope="session")

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -139,7 +139,7 @@ def testdir(testdir: Testdir) -> Testdir:
 
 @pytest.fixture
 def symlink_or_skip():
-    """Return a function to create symlinks or skip the test.
+    """Return a function that creates a symlink or raises ``Skip``.
 
     On Windows `os.symlink` is available, but normal users require special
     admin privileges to create symlinks.


### PR DESCRIPTION
This was done on purpose in 7268462b3, and then reverted in a non-merge
"Merge" commit (wrong conflict resolution?):
https://github.com/pytest-dev/pytest/pull/4158/commits/9646a1cd7#diff-1f1fc4eef6bf4c4da558e0dce9e74e9bR761-R762