### PR TITLE
WIP POC RFC: remove config/session as possible parameters for node

### DIFF
--- a/src/_pytest/main.py
+++ b/src/_pytest/main.py
@@ -374,9 +374,11 @@ class Session(nodes.FSCollector):
     _setupstate = None  # type: SetupState
 
     def __init__(self, config):
-        nodes.FSCollector.__init__(
-            self, config.rootdir, parent=None, config=config, session=self, nodeid=""
-        )
+        self.config = config
+        self.fspath = config.rootdir
+        self.session = self
+        super().__init__(fspath=config.rootdir, parent=self, nodeid="")
+        self.parent = None
         self.testsfailed = 0
         self.testscollected = 0
         self.shouldstop = False

--- a/src/_pytest/python.py
+++ b/src/_pytest/python.py
@@ -539,11 +539,9 @@ class Module(nodes.File, PyCollector):
 
 
 class Package(Module):
-    def __init__(self, fspath, parent=None, config=None, session=None, nodeid=None):
+    def __init__(self, fspath, parent=None, nodeid=None):
         session = parent.session
-        nodes.FSCollector.__init__(
-            self, fspath, parent=parent, config=config, session=session, nodeid=nodeid
-        )
+        nodes.FSCollector.__init__(self, fspath, parent=parent, nodeid=nodeid)
         self.name = fspath.dirname
         self.trace = session.trace
         self._norecursepatterns = session._norecursepatterns
@@ -1405,15 +1403,13 @@ class Function(FunctionMixin, nodes.Item):
         name,
         parent,
         args=None,
-        config=None,
         callspec=None,
         callobj=NOTSET,
         keywords=None,
-        session=None,
         fixtureinfo=None,
         originalname=None,
     ):
-        super().__init__(name, parent, config=config, session=session)
+        super().__init__(name=name, parent=parent)
         self._args = args
         if callobj is not NOTSET:
             self.obj = callobj

--- a/testing/deprecated_test.py
+++ b/testing/deprecated_test.py
@@ -79,14 +79,26 @@ def test_warn_about_imminent_junit_family_default_change(testdir, junit_family):
 
 
 def test_node_direct_ctor_warning():
-    class MockConfig:
-        pass
+    class MockAll:
+        @property
+        def parent(self):
+            return None
 
-    ms = MockConfig()
+        @property
+        def config(self):
+            return self
+
+        @property
+        def session(self):
+            return self
+
+        fspath = None
+
+    ms = MockAll()
     with pytest.warns(
         DeprecationWarning,
         match="direct construction of .* has been deprecated, please use .*.from_parent",
     ) as w:
-        nodes.Node(name="test", config=ms, session=ms, nodeid="None")
+        nodes.Node(name="test", parent=ms, nodeid="None")
     assert w[0].lineno == inspect.currentframe().f_lineno - 1
     assert w[0].filename == __file__

--- a/testing/example_scripts/fixtures/custom_item/conftest.py
+++ b/testing/example_scripts/fixtures/custom_item/conftest.py
@@ -1,10 +1,10 @@
 import pytest
 
 
-class CustomItem(pytest.Item, pytest.File):
+class CustomItem(pytest.Item):
     def runtest(self):
         pass
 
 
 def pytest_collect_file(path, parent):
-    return CustomItem(path, parent)
+    return CustomItem.from_parent(parent, fspath=path)

--- a/testing/python/collect.py
+++ b/testing/python/collect.py
@@ -284,7 +284,7 @@ class TestFunction:
         session = testdir.Session.from_config(config)
         session._fixturemanager = FixtureManager(session)
 
-        return pytest.Function.from_parent(config=config, parent=session, **kwargs)
+        return pytest.Function.from_parent(parent=session, **kwargs)
 
     def test_function_equality(self, testdir, tmpdir):
         def func1():

--- a/testing/python/fixtures.py
+++ b/testing/python/fixtures.py
@@ -1534,6 +1534,7 @@ class TestFixtureManagerParseFactories:
         reprec = testdir.inline_run()
         reprec.assertoutcome(passed=2)
 
+    @pytest.mark.xfail(reason="file item dulity mess")
     def test_collect_custom_items(self, testdir):
         testdir.copy_example("fixtures/custom_item")
         result = testdir.runpytest("foo")

--- a/testing/test_collection.py
+++ b/testing/test_collection.py
@@ -746,6 +746,7 @@ class Test_genitems:
         assert ids == ["MyTestSuite.x_test", "TestCase.test_y"]
 
 
+@pytest.mark.xfail(reason="item<>file missmatch, a mess we should break")
 def test_matchnodes_two_collections_same_file(testdir):
     testdir.makeconftest(
         """
@@ -756,18 +757,18 @@ def test_matchnodes_two_collections_same_file(testdir):
         class Plugin2(object):
             def pytest_collect_file(self, path, parent):
                 if path.ext == ".abc":
-                    return MyFile2(path, parent)
+                    return MyFile2.from_parent(parent, fspath=path)
 
         def pytest_collect_file(path, parent):
             if path.ext == ".abc":
-                return MyFile1(path, parent)
+                return MyFile1.from_parent(parent, fspath=path)
 
-        class MyFile1(pytest.Item, pytest.File):
+        class MyFile1(pytest.Item):
             def runtest(self):
                 pass
         class MyFile2(pytest.File):
             def collect(self):
-                return [Item2("hello", parent=self)]
+                return [Item2.from_parent(name="hello", parent=self)]
 
         class Item2(pytest.Item):
             def runtest(self):


### PR DESCRIPTION
this removes the ability to pass session/config to nodes directly, and in turn exposes a few breakages in hierarchy we implicitly allowed (but shouldn't have to begin with)

I'll work out details of deprecation and moving to this later