### PR TITLE
WIP hack around mark object [skip ci]

### DIFF
--- a/src/_pytest/mark/structures.py
+++ b/src/_pytest/mark/structures.py
@@ -214,7 +214,7 @@ class MarkDecorator:
 
     """
 
-    mark = attr.ib(validator=attr.validators.instance_of(Mark))
+    mark = attr.ib()
 
     @property
     def name(self):
@@ -278,20 +278,13 @@ def normalize_mark_list(mark_list):
     :type mark_list: List[Union[Mark, Markdecorator]]
     :rtype: List[Mark]
     """
-    extracted = [
-        getattr(mark, "mark", mark) for mark in mark_list
-    ]  # unpack MarkDecorator
-    for mark in extracted:
-        if not isinstance(mark, Mark):
-            raise TypeError("got {!r} instead of Mark".format(mark))
-    return [x for x in extracted if isinstance(x, Mark)]
+    return [getattr(mark, "mark", mark) for mark in mark_list]  # unpack MarkDecorator
 
 
 def store_mark(obj, mark):
     """store a Mark on an object
     this is used to implement the Mark declarations/decorators correctly
     """
-    assert isinstance(mark, Mark), mark
     # always reassign name to avoid updating pytestmark
     # in a reference that was only borrowed
     obj.pytestmark = get_unpacked_marks(obj) + [mark]
@@ -351,6 +344,9 @@ class MarkGenerator:
                 )
 
         return MarkDecorator(Mark(name, (), {}))
+
+    def __call__(self, m):
+        return MarkDecorator(m)
 
 
 MARK_GEN = MarkGenerator()


### PR DESCRIPTION
Hey @RonnyPfannschmidt,

The topic of mark objects came up at work again, and I decided to be a bit of hacking to see how far I could get based on the discussion in https://github.com/pytest-dev/pytest/issues/5424.

I basically removed some checks and made `MarkDecorator` callable, so this is possible:

```python
import attr

import pytest


@attr.s
class MyMark:
    name = attr.ib(type=str)
    x = attr.ib(type=int)


@pytest.mark(MyMark('mymark', 10))
def test(request):
    m = request.node.get_closest_marker(name='mymark')
    assert isinstance(MyMark)
    assert m.x == 10
```

No registration necessary, just a plain object with the only restriction that it needs to have a `name: str` attribute (which can also be lifted easily).

Wanted to share because I'm excited that this was possible with so little work (thanks to all the previous work you've done here of course).