### PR TITLE
doc: highlight difference between progress percentage & code coverage

### DIFF
--- a/doc/en/capture.rst
+++ b/doc/en/capture.rst
@@ -93,6 +93,11 @@ of the failing function and hide the other one:
     setting up <function test_func2 at 0xdeadbeef>
     ======================= 1 failed, 1 passed in 0.12s ========================
 
+.. note:: The ``[100%]`` (or other right-aligned percentages on the same line
+    as a ``test_….py`` file) indicate the `progress of running all test cases
+    <https://blog.pytest.org/2017/whats-new-in-pytest-33/>`_, not the code coverage.
+    To obtain the latter, use `pytest-cov <https://pypi.org/project/pytest-cov/>`_.
+
 Accessing captured output from a test function
 ---------------------------------------------------
 

--- a/doc/en/capture.rst
+++ b/doc/en/capture.rst
@@ -93,11 +93,6 @@ of the failing function and hide the other one:
     setting up <function test_func2 at 0xdeadbeef>
     ======================= 1 failed, 1 passed in 0.12s ========================
 
-.. note:: The ``[100%]`` (or other right-aligned percentages on the same line
-    as a ``test_….py`` file) indicate the `progress of running all test cases
-    <https://blog.pytest.org/2017/whats-new-in-pytest-33/>`_, not the code coverage.
-    To obtain the latter, use `pytest-cov <https://pypi.org/project/pytest-cov/>`_.
-
 Accessing captured output from a test function
 ---------------------------------------------------
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -77,6 +77,13 @@ This test returns a failure report because ``func(3)`` does not return ``5``.
 
     You can use the ``assert`` statement to verify test expectations. pytest’s `Advanced assertion introspection <http://docs.python.org/reference/simple_stmts.html#the-assert-statement>`_ will intelligently report intermediate values of the assert expression so you can avoid the many names `of JUnit legacy methods <http://docs.python.org/library/unittest.html#test-cases>`_.
 
+.. note::
+
+    The ``[100%]`` (or other right-aligned percentages on the same line
+    as a ``test_….py`` file) indicate the `progress of running all test cases
+    <https://blog.pytest.org/2017/whats-new-in-pytest-33/>`_, not the code coverage.
+    To obtain the latter, use `pytest-cov <https://pypi.org/project/pytest-cov/>`_.
+
 Run multiple tests
 ----------------------------------------------------------
 

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -73,11 +73,9 @@ That’s it. You can now execute the test function:
 
 The ``[100%]`` refer to the overall progress of running all test cases. After it finishes, pytest then shows a failure report because ``func(3)`` does not return ``5``.
 
-
 .. note::
 
     You can use the ``assert`` statement to verify test expectations. pytest’s `Advanced assertion introspection <http://docs.python.org/reference/simple_stmts.html#the-assert-statement>`_ will intelligently report intermediate values of the assert expression so you can avoid the many names `of JUnit legacy methods <http://docs.python.org/library/unittest.html#test-cases>`_.
-
 
 Run multiple tests
 ----------------------------------------------------------

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -71,18 +71,13 @@ That’s it. You can now execute the test function:
     test_sample.py:6: AssertionError
     ============================ 1 failed in 0.12s =============================
 
-This test returns a failure report because ``func(3)`` does not return ``5``.
+The ``[100%]`` refer to the overall progress of running all test cases. After it finishes, pytest then shows a failure report because ``func(3)`` does not return ``5``.
+
 
 .. note::
 
     You can use the ``assert`` statement to verify test expectations. pytest’s `Advanced assertion introspection <http://docs.python.org/reference/simple_stmts.html#the-assert-statement>`_ will intelligently report intermediate values of the assert expression so you can avoid the many names `of JUnit legacy methods <http://docs.python.org/library/unittest.html#test-cases>`_.
 
-.. note::
-
-    The ``[100%]`` (or other right-aligned percentages on the same line
-    as a ``test_….py`` file) indicate the `progress of running all test cases
-    <https://blog.pytest.org/2017/whats-new-in-pytest-33/>`_, not the code coverage.
-    To obtain the latter, use `pytest-cov <https://pypi.org/project/pytest-cov/>`_.
 
 Run multiple tests
 ----------------------------------------------------------

--- a/doc/en/getting-started.rst
+++ b/doc/en/getting-started.rst
@@ -71,7 +71,7 @@ That’s it. You can now execute the test function:
     test_sample.py:6: AssertionError
     ============================ 1 failed in 0.12s =============================
 
-The ``[100%]`` refer to the overall progress of running all test cases. After it finishes, pytest then shows a failure report because ``func(3)`` does not return ``5``.
+The ``[100%]`` refers to the overall progress of running all test cases. After it finishes, pytest then shows a failure report because ``func(3)`` does not return ``5``.
 
 .. note::
 


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [x] Target the `master` branch for bug fixes, documentation updates and trivial changes.
- [-] Target the `features` branch for new features, improvements, and removals/deprecations.
- [-] Include documentation when adding new features.
- [-] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [-] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [-] Add yourself to `AUTHORS` in alphabetical order.
-->

[Some people](https://stackoverflow.com/questions/49738081/) and me as well were a bit confused about the `[...%]` indicators in stout. Since I didn't find a specific mention that it's not the code/test _coverage_, how about to add it here?

I hope my rst syntax is correct. GitHub at least rendered it OK, but I didn't re-build the docu locally. Can do that in the next few days if needed.
