### PR TITLE
Changing key "error" to "errors" to maintain plurality

### DIFF
--- a/src/_pytest/junitxml.py
+++ b/src/_pytest/junitxml.py
@@ -469,7 +469,7 @@ class LogXML:
         self.log_passing_tests = log_passing_tests
         self.report_duration = report_duration
         self.family = family
-        self.stats = dict.fromkeys(["error", "passed", "failure", "skipped"], 0)
+        self.stats = dict.fromkeys(["errors", "passed", "failure", "skipped"], 0)
         self.node_reporters = {}  # nodeid -> _NodeReporter
         self.node_reporters_ordered = []
         self.global_properties = []
@@ -641,7 +641,7 @@ class LogXML:
             self.stats["passed"]
             + self.stats["failure"]
             + self.stats["skipped"]
-            + self.stats["error"]
+            + self.stats["errors"]
             - self.cnt_double_fail_tests
         )
         logfile.write('<?xml version="1.0" encoding="utf-8"?>')
@@ -650,7 +650,7 @@ class LogXML:
             self._get_global_properties_node(),
             [x.to_xml() for x in self.node_reporters_ordered],
             name=self.suite_name,
-            errors=self.stats["error"],
+            errors=self.stats["errors"],
             failures=self.stats["failure"],
             skipped=self.stats["skipped"],
             tests=numtests,

--- a/src/_pytest/pytester.py
+++ b/src/_pytest/pytester.py
@@ -444,9 +444,8 @@ class RunResult:
                 break
         else:
             raise ValueError("Pytest terminal summary report not found")
-        if "errors" in ret:
-            assert "error" not in ret
-            ret["error"] = ret.pop("errors")
+        if "error" in ret:
+            ret["errors"] = ret.pop("error")
         return ret
 
     def assert_outcomes(
@@ -468,7 +467,7 @@ class RunResult:
             "passed": d.get("passed", 0),
             "skipped": d.get("skipped", 0),
             "failed": d.get("failed", 0),
-            "error": d.get("error", 0),
+            "errors": d.get("errors", 0),
             "xpassed": d.get("xpassed", 0),
             "xfailed": d.get("xfailed", 0),
         }
@@ -476,7 +475,7 @@ class RunResult:
             "passed": passed,
             "skipped": skipped,
             "failed": failed,
-            "error": error,
+            "errors": error,
             "xpassed": xpassed,
             "xfailed": xfailed,
         }

--- a/src/_pytest/runner.py
+++ b/src/_pytest/runner.py
@@ -171,7 +171,7 @@ def pytest_report_teststatus(report):
     if report.when in ("setup", "teardown"):
         if report.failed:
             #      category, shortletter, verbose-word
-            return "error", "E", "ERROR"
+            return "errors", "E", "ERROR"
         elif report.skipped:
             return "skipped", "s", "SKIPPED"
         else:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -43,7 +43,7 @@ KNOWN_TYPES = (
     "xfailed",
     "xpassed",
     "warnings",
-    "error",
+    "errors",
 )
 
 _REPORTCHARS_DEFAULT = "fE"
@@ -216,7 +216,7 @@ def pytest_report_teststatus(report: TestReport) -> Tuple[str, str, str]:
 
     outcome = report.outcome
     if report.when in ("collect", "setup", "teardown") and outcome == "failed":
-        outcome = "error"
+        outcome = "errors"
         letter = "E"
 
     return outcome, letter, outcome.upper()
@@ -559,7 +559,7 @@ class TerminalReporter:
 
     def pytest_collectreport(self, report: CollectReport) -> None:
         if report.failed:
-            self._add_stats("error", [report])
+            self._add_stats("errors", [report])
         elif report.skipped:
             self._add_stats("skipped", [report])
         items = [x for x in report.result if isinstance(x, pytest.Item)]
@@ -581,7 +581,7 @@ class TerminalReporter:
                 return
             self._collect_report_last_write = t
 
-        errors = len(self.stats.get("error", []))
+        errors = len(self.stats.get("errors", []))
         skipped = len(self.stats.get("skipped", []))
         deselected = len(self.stats.get("deselected", []))
         selected = self._numcollected - errors - skipped - deselected
@@ -929,11 +929,11 @@ class TerminalReporter:
 
     def summary_errors(self):
         if self.config.option.tbstyle != "no":
-            reports = self.getreports("error")
+            reports = self.getreports("errors")
             if not reports:
                 return
             self.write_sep("=", "ERRORS")
-            for rep in self.stats["error"]:
+            for rep in self.stats["errors"]:
                 msg = self._getfailureheadline(rep)
                 if rep.when == "collect":
                     msg = "ERROR collecting " + msg
@@ -1047,7 +1047,7 @@ class TerminalReporter:
             "f": partial(show_simple, "failed"),
             "s": show_skipped,
             "p": partial(show_simple, "passed"),
-            "E": partial(show_simple, "error"),
+            "E": partial(show_simple, "errors"),
         }  # type: Mapping[str, Callable[[List[str]], None]]
 
         lines = []  # type: List[str]
@@ -1070,7 +1070,7 @@ class TerminalReporter:
 
     def _determine_main_color(self, unknown_type_seen: bool) -> str:
         stats = self.stats
-        if "failed" in stats or "error" in stats:
+        if "failed" in stats or "errors" in stats:
             main_color = "red"
         elif "warnings" in stats or "xpassed" in stats or unknown_type_seen:
             main_color = "yellow"
@@ -1176,7 +1176,7 @@ def _folded_skips(skipped):
 
 _color_for_type = {
     "failed": "red",
-    "error": "red",
+    "errors": "red",
     "warnings": "yellow",
     "passed": "green",
 }
@@ -1185,12 +1185,12 @@ _color_for_type_default = "yellow"
 
 def _make_plural(count, noun):
     # No need to pluralize words such as `failed` or `passed`.
-    if noun not in ["error", "warnings"]:
+    if noun not in ["errors", "warnings"]:
         return count, noun
 
     # The `warnings` key is plural. To avoid API breakage, we keep it that way but
     # set it to singular here so we can determine plurality in the same way as we do
-    # for `error`.
+    # for `errors`.
     noun = noun.replace("warnings", "warning")
 
     return count, noun + "s" if count != 1 else noun

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -1192,6 +1192,7 @@ def _make_plural(count, noun):
     # set it to singular here so we can determine plurality in the same way as we do
     # for `errors`.
     noun = noun.replace("warnings", "warning")
+    noun = noun.replace("errors", "error")
 
     return count, noun + "s" if count != 1 else noun
 

--- a/testing/example_scripts/junit-10.xsd
+++ b/testing/example_scripts/junit-10.xsd
@@ -46,7 +46,7 @@ THE SOFTWARE.
         </xs:complexType>
     </xs:element>
 
-    <xs:element name="error">
+    <xs:element name="errors">
         <xs:complexType mixed="true">
             <xs:attribute name="type" type="xs:string"/>
             <xs:attribute name="message" type="xs:string"/>
@@ -87,7 +87,7 @@ THE SOFTWARE.
             <xs:sequence>
                 <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="skipped"/>
-                    <xs:element ref="error"/>
+                    <xs:element ref="errors"/>
                     <xs:element ref="failure"/>
                     <xs:element ref="rerunFailure" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element ref="rerunError" minOccurs="0" maxOccurs="unbounded"/>

--- a/testing/test_junitxml.py
+++ b/testing/test_junitxml.py
@@ -270,7 +270,7 @@ class TestPython:
         node.assert_attr(errors=1, tests=1)
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(classname="test_setup_error", name="test_function")
-        fnode = tnode.find_first_by_tag("error")
+        fnode = tnode.find_first_by_tag("errors")
         fnode.assert_attr(message="test setup failure")
         assert "ValueError" in fnode.toxml()
 
@@ -293,7 +293,7 @@ class TestPython:
         node = dom.find_first_by_tag("testsuite")
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(classname="test_teardown_error", name="test_function")
-        fnode = tnode.find_first_by_tag("error")
+        fnode = tnode.find_first_by_tag("errors")
         fnode.assert_attr(message="test teardown failure")
         assert "ValueError" in fnode.toxml()
 
@@ -320,7 +320,7 @@ class TestPython:
             assert 0
         fnode = first.find_first_by_tag("failure")
         fnode.assert_attr(message="Exception: Call Exception")
-        snode = second.find_first_by_tag("error")
+        snode = second.find_first_by_tag("errors")
         snode.assert_attr(message="test teardown failure")
 
     @parametrize_families
@@ -442,7 +442,7 @@ class TestPython:
         node.assert_attr(errors=1, tests=1)
         tnode = node.find_first_by_tag("testcase")
         tnode.assert_attr(classname="pytest", name="internal")
-        fnode = tnode.find_first_by_tag("error")
+        fnode = tnode.find_first_by_tag("errors")
         fnode.assert_attr(message="internal error")
         assert "Division" in fnode.toxml()
 
@@ -688,7 +688,7 @@ class TestPython:
         node = dom.find_first_by_tag("testsuite")
         node.assert_attr(errors=1, tests=1)
         tnode = node.find_first_by_tag("testcase")
-        fnode = tnode.find_first_by_tag("error")
+        fnode = tnode.find_first_by_tag("errors")
         fnode.assert_attr(message="collection failure")
         assert "SyntaxError" in fnode.toxml()
 

--- a/testing/test_meta.py
+++ b/testing/test_meta.py
@@ -27,7 +27,7 @@ def test_no_warnings(module):
     # fmt: off
     subprocess.check_call((
         sys.executable,
-        "-W", "error",
+        "-W", "errors",
         # https://github.com/pytest-dev/pytest/issues/5901
         "-W", "ignore:The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.:DeprecationWarning",  # noqa: E501
         "-c", "import {}".format(module),

--- a/testing/test_pytester.py
+++ b/testing/test_pytester.py
@@ -712,6 +712,25 @@ def test_run_result_repr() -> None:
     )
 
 
+def test_testdir_outcomes_with_single_error(testdir):
+    p1 = testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def bad_fixture():
+            raise Exception("bad")
+
+        def test_error1(bad_fixture):
+            pass
+    """
+    )
+    result = testdir.runpytest(str(p1))
+    result.assert_outcomes(error=1)
+
+    assert result.parseoutcomes() == {"errors": 1}
+
+
 def test_testdir_outcomes_with_multiple_errors(testdir):
     p1 = testdir.makepyfile(
         """
@@ -731,7 +750,7 @@ def test_testdir_outcomes_with_multiple_errors(testdir):
     result = testdir.runpytest(str(p1))
     result.assert_outcomes(error=2)
 
-    assert result.parseoutcomes() == {"error": 2}
+    assert result.parseoutcomes() == {"errors": 2}
 
 
 def test_makefile_joins_absolute_path(testdir: Testdir) -> None:

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1461,15 +1461,15 @@ def tr() -> TerminalReporter:
             ],
             {"failed": (1,), "passed": (1,)},
         ),
-        ("red", [("1 error", {"bold": True, "red": True})], {"error": (1,)}),
-        ("red", [("2 errors", {"bold": True, "red": True})], {"error": (1, 2)}),
+        ("red", [("1 error", {"bold": True, "red": True})], {"errors": (1,)}),
+        ("red", [("2 errors", {"bold": True, "red": True})], {"errors": (1, 2)}),
         (
             "red",
             [
                 ("1 passed", {"bold": False, "green": True}),
                 ("1 error", {"bold": True, "red": True}),
             ],
-            {"error": (1,), "passed": (1,)},
+            {"errors": (1,), "passed": (1,)},
         ),
         # (a status that's not known to the code)
         ("yellow", [("1 weird", {"bold": True, "yellow": True})], {"weird": (1,)}),
@@ -2082,7 +2082,7 @@ def test_collecterror(testdir):
             "*_ ERROR collecting test_collecterror.py _*",
             "E   SyntaxError: *",
             "*= short test summary info =*",
-            "ERROR test_collecterror.py",
+            "ERRORS test_collecterror.py",
             "*! Interrupted: 1 error during collection !*",
             "*= 1 error in *",
         ]


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [X] Allow maintainers to push and squash when merging my commits. Please uncheck this if you prefer to squash the commits yourself.

Unless your change is trivial or a small documentation fix (e.g., a typo or reword of a small section) please:

- [ ] Create a new changelog file in the `changelog` folder, with a name like `<ISSUE NUMBER>.<TYPE>.rst`. See [changelog/README.rst](https://github.com/pytest-dev/pytest/blob/master/changelog/README.rst) for details.

  Write sentences in the **past or present tense**, examples:

  * *Improved verbose diff output with sequences.*
  * *Terminal summary statistics now use multiple colors.*

  Also make sure to end the sentence with a `.`.

- [ ] Add yourself to `AUTHORS` in alphabetical order.
-->

This pull request was created to try and fix issue #6505
"error" has been changed to "errors" without affecting the user-facing text.
When testing the changes, there was one module that wouldn't pass (testing/test_junitxml.py).
I've tried to look deeper into this and saw that when an xmlschema is created, there is an <error /> node created instead of <errors />. It looks like the "s" is being dropped from "errors" in the junit-10.xsd file which ends up in creating that node.

I'm not sure where to look further in order to fix the failed test cases. If you know which direction I should take in order to fix this I'd gladly move in that direction. @blueyed 