### PR TITLE
terminal: fix progress report with duplicate nodeids

### DIFF
--- a/changelog/6597.bugfix.rst
+++ b/changelog/6597.bugfix.rst
@@ -1,0 +1,1 @@
+Fix percentage progress report with duplicate nodeids.

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -480,7 +480,11 @@ class TerminalReporter:
     def pytest_runtestloop(self) -> Generator[None, None, None]:
         """Write final progress indicator."""
         yield
-        if self.verbosity <= 0 and self._show_progress_info:
+        if (
+            getattr(self, "_tests_ran", False)
+            and self.verbosity <= 0
+            and self._show_progress_info
+        ):
             self._write_progress_information_filling_space()
 
     def _get_progress_information_message(self) -> str:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -414,8 +414,6 @@ class TerminalReporter:
         else:
             markup = None
         self.stats.setdefault(category, []).append(rep)
-        if rep.when == "setup":
-            self._numreported += 1
         if not letter and not word:
             # probably passed setup/teardown
             return
@@ -458,6 +456,7 @@ class TerminalReporter:
 
     def pytest_runtest_logfinish(self, nodeid):
         assert self._session
+        self._numreported += 1
         if self.verbosity <= 0 and self._show_progress_info:
             if self._show_progress_info == "count":
                 num_tests = self._session.testscollected

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -468,6 +468,9 @@ class TerminalReporter:
 
             is_last_item = self._numreported == self._session.testscollected
             if is_last_item:
+                if hasattr(self, "_last_item_reported"):
+                    assert 0, self._last_item_reported
+                self._last_item_reported = nodeid
                 self._write_progress_information_filling_space(color=main_color)
             else:
                 w = self._width_of_current_line

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -486,7 +486,7 @@ class TerminalReporter:
     def _is_last_item(self):
         return self._progress_items_reported == self._session.testscollected
 
-    def pytest_runtest_teardown(self) -> None:
+    def pytest_runtest_logfinish(self) -> None:
         """Write progress if past edge."""
         if self.verbosity >= 0 or not self._show_progress_info:
             return

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -482,6 +482,10 @@ class TerminalReporter:
                 self._tw.write(" " + line)
                 self.currentfspath = -2
 
+    @property
+    def _is_last_item(self):
+        return self._progress_items_reported == self._session.testscollected
+
     def pytest_runtest_teardown(self) -> None:
         """Write progress if past edge."""
         if self.verbosity >= 0 or not self._show_progress_info:
@@ -1039,10 +1043,6 @@ class TerminalReporter:
             self.write_sep("=", "short test summary info")
             for line in lines:
                 self.write_line(line)
-
-    @property
-    def _is_last_item(self):
-        return self._progress_items_reported == self._session.testscollected
 
     def _get_main_color(self) -> Tuple[str, List[str]]:
         if self._main_color is None or self._known_types is None or self._is_last_item:

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -414,6 +414,8 @@ class TerminalReporter:
         else:
             markup = None
         self.stats.setdefault(category, []).append(rep)
+        if rep.when == "setup":
+            self._numreported += 1
         if not letter and not word:
             # probably passed setup/teardown
             return
@@ -436,8 +438,6 @@ class TerminalReporter:
             else:
                 self._tw.write(letter, **markup)
         else:
-            if rep.when == "call":
-                self._numreported += 1
             line = self._locationline(rep.nodeid, *rep.location)
             if not running_xdist:
                 self.write_ensure_prefix(line, word, **markup)

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -467,7 +467,6 @@ class TerminalReporter:
 
             main_color, _ = _get_main_color(self.stats)
 
-            self._numreported += 1
             is_last_item = self._numreported == self._session.testscollected
             if is_last_item:
                 self._write_progress_information_filling_space(color=main_color)

--- a/src/_pytest/terminal.py
+++ b/src/_pytest/terminal.py
@@ -440,7 +440,7 @@ class TerminalReporter:
         else:
             markup = None
         self._add_stats(category, [rep])
-        if rep.when == "setup":
+        if rep.when == "call" or (rep.when == "setup" and rep.failed):
             self._progress_items_reported += 1
         if not letter and not word:
             # probably passed setup/teardown

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1597,6 +1597,31 @@ class TestProgressOutputStyle:
             ]
         )
 
+    def test_same_nodeids(self, testdir: Testdir) -> None:
+        p1 = testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.parametrize("v", ["", " "])
+            @pytest.mark.parametrize("w", ["", " "])
+            def test(v, w):
+                pass
+            """
+        )
+        result = testdir.runpytest("-v", str(p1))
+        trans = str.maketrans({"[": "[[]", "]": "[]]"})
+        result.stdout.fnmatch_lines(
+            [
+                line.translate(trans)
+                for line in [
+                    "test_same_nodeids.py::test[] PASSED * [ 25%]",
+                    "test_same_nodeids.py::test[ ] PASSED * [ 50%]",
+                    "test_same_nodeids.py::test[ ] PASSED * [ 75%]",
+                    "test_same_nodeids.py::test[ - ] PASSED * [100%]",
+                ]
+            ]
+        )
+
     def test_colored_progress(self, testdir, monkeypatch):
         monkeypatch.setenv("PY_COLORS", "1")
         testdir.makepyfile(

--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -1598,26 +1598,26 @@ class TestProgressOutputStyle:
         )
 
     def test_same_nodeids(self, testdir: Testdir) -> None:
+        p1 = testdir.makeconftest(
+            """
+            def pytest_collection_modifyitems(items):
+                assert len(items) == 2
+                items[1]._nodeid = items[0].nodeid
+            """
+        )
         p1 = testdir.makepyfile(
             """
-            import pytest
-
-            @pytest.mark.parametrize("v", ["", " "])
-            @pytest.mark.parametrize("w", ["", " "])
-            def test(v, w):
-                pass
+            def test1(): pass
+            def test2(): pass
             """
         )
         result = testdir.runpytest("-v", str(p1))
-        trans = str.maketrans({"[": "[[]", "]": "[]]"})
         result.stdout.fnmatch_lines(
             [
-                line.translate(trans)
+                line.translate(TRANS_FNMATCH)
                 for line in [
-                    "test_same_nodeids.py::test[] PASSED * [ 25%]",
-                    "test_same_nodeids.py::test[ ] PASSED * [ 50%]",
-                    "test_same_nodeids.py::test[ ] PASSED * [ 75%]",
-                    "test_same_nodeids.py::test[ - ] PASSED * [100%]",
+                    "test_same_nodeids.py::test1 PASSED * [50%]",
+                    "test_same_nodeids.py::test2 PASSED * [100%]",
                 ]
             ]
         )


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/pytest/issues/6597.

TODO:

- [x] after https://github.com/pytest-dev/pytest/pull/6409
- [x] test with tests having an error during "setup" already.
- [x] adjust test to reliably use duplicate nodeids?  (https://github.com/pytest-dev/pytest/issues/6597#issuecomment-579280434)