### PR TITLE
[on hold] Fix CaptureManager.read_global_capture after stop

### DIFF
--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -141,6 +141,8 @@ class CaptureManager:
         self.resume_fixture(self._current_item)
 
     def read_global_capture(self):
+        if not self._global_capturing:
+            return CaptureResult("", "")
         return self._global_capturing.readouterr()
 
     # Fixture Control (it's just forwarding, think about removing this later)

--- a/src/_pytest/capture.py
+++ b/src/_pytest/capture.py
@@ -141,9 +141,9 @@ class CaptureManager:
         self.resume_fixture(self._current_item)
 
     def read_global_capture(self):
-        if not self._global_capturing:
-            return CaptureResult("", "")
-        return self._global_capturing.readouterr()
+        if self._global_capturing:
+            return self._global_capturing.readouterr()
+        return CaptureResult("", "")
 
     # Fixture Control (it's just forwarding, think about removing this later)
 

--- a/testing/test_capture.py
+++ b/testing/test_capture.py
@@ -77,6 +77,8 @@ class TestCaptureManager:
             if method != "no":
                 assert out == "hello\n"
             capman.stop_global_capturing()
+            # Reading after stopping does not crash, but returns empty values.
+            assert capman.read_global_capture() == capture.CaptureResult("", "")
         finally:
             capouter.stop_capturing()
 


### PR DESCRIPTION
There are several places that use `read_global_capture` after
`stop_global_capturing` might have been used, e.g. via
`pytest_internalerror` etc, where it shouldn't crash then more.

TODO:

- [ ] changelog
- [ ] test (where this might get triggered, but not really worth it probably)