### PR TITLE
Disallow Any on public interface types

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -204,6 +204,7 @@ Nicholas Murphy
 Niclas Olofsson
 Nicolas Delaby
 Nikolay Kondratyev
+Nipunn Koorapati
 Oleg Pidsadnyi
 Oleg Sushchenko
 Oliver Bestwalter

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,3 +70,18 @@ strict_equality = True
 warn_redundant_casts = True
 warn_return_any = True
 warn_unused_configs = True
+
+# Hold the public interface to a higher standard
+[mypy-pytest]
+# Disallow dynamic typing
+disallow_any_decorated = True
+disallow_any_expr = True
+disallow_any_generics = True
+disallow_any_unimported = True
+disallow_subclassing_any = True
+
+# Disallow untyped definitions/calls
+disallow_incomplete_defs = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True

--- a/src/_pytest/__init__.py
+++ b/src/_pytest/__init__.py
@@ -1,7 +1,9 @@
 __all__ = ["__version__"]
 
 try:
-    from ._version import version as __version__
+    from ._version import version
+
+    __version__ = version  # type: str
 except ImportError:
     # broken installation, we don't even try
     # unknown only works because we do poor mans version compare

--- a/src/pytest/__init__.py
+++ b/src/pytest/__init__.py
@@ -46,8 +46,57 @@ from _pytest.warning_types import PytestUnhandledCoroutineWarning
 from _pytest.warning_types import PytestUnknownMarkWarning
 from _pytest.warning_types import PytestWarning
 
+# For mypy Any type checking purposes.
+# This file sets disallow_any_expr to ensure that the public API
+# does not have dynamic typing via Any. Manually using each public API
+# type as an expression to enforce this.
+__version__ = __version__
+register_assert_rewrite = register_assert_rewrite
+_setup_collect_fakemodule = _setup_collect_fakemodule
+cmdline = cmdline
+ExitCode = ExitCode
+# hookimpl = hookimpl
+# hookspec = hookspec
+main = main
+UsageError = UsageError
+__pytestPDB = __pytestPDB
+_fillfuncargs = _fillfuncargs
+fixture = fixture
+yield_fixture = yield_fixture
+freeze_includes = freeze_includes
+Session = Session
+mark = mark
+param = param
+Collector = Collector
+File = File
+Item = Item
+exit = exit
+fail = fail
+importorskip = importorskip
+skip = skip
+xfail = xfail
+Class = Class
+Function = Function
+Instance = Instance
+Module = Module
+Package = Package
+approx = approx
+raises = raises
+deprecated_call = deprecated_call
+warns = warns
+PytestAssertRewriteWarning = PytestAssertRewriteWarning
+PytestCacheWarning = PytestCacheWarning
+PytestCollectionWarning = PytestCollectionWarning
+PytestConfigWarning = PytestConfigWarning
+PytestDeprecationWarning = PytestDeprecationWarning
+PytestExperimentalApiWarning = PytestExperimentalApiWarning
+PytestUnhandledCoroutineWarning = PytestUnhandledCoroutineWarning
+PytestUnknownMarkWarning = PytestUnknownMarkWarning
+PytestWarning = PytestWarning
 
-set_trace = __pytestPDB.set_trace
+
+# Allow set_trace() to be typed with None
+set_trace = __pytestPDB.set_trace  # type: ignore
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
This ensures that public interface methods must be typed
This should help with #3342

Per discussion there, ideally we shouldn't require full typing before we move forward, but this should give us a sense of the typing coverage which we have currently.