### PR TITLE
Fix tests: use explicit syspathinsert

### DIFF
--- a/testing/test_assertion.py
+++ b/testing/test_assertion.py
@@ -1264,6 +1264,7 @@ def test_exception_handling_no_traceback(testdir):
             multitask_job()
     """
     )
+    testdir.syspathinsert()
     result = testdir.runpytest(p1, "--tb=long")
     result.stdout.fnmatch_lines(
         [

--- a/testing/test_reports.py
+++ b/testing/test_reports.py
@@ -362,6 +362,7 @@ class TestReportSerialization:
             """
             )
 
+        testdir.syspathinsert()
         reprec = testdir.inline_run()
 
         reports = reprec.getreports("pytest_runtest_logreport")


### PR DESCRIPTION
Use `testdir.syspathinsert()` with multiprocessing tests:

- `test_chained_exceptions_no_reprcrash`
- `test_exception_handling_no_traceback`

This only works currently because `_importtestmodule` changes `sys.path`
as a side-effect.

It appears to be only required on Windows though - likely due to the
multiprocessing method used there.